### PR TITLE
set force ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
@@ -92,7 +92,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # パスワードリセットの設定（Gmail）
-  config.action_mailer.default_url_options = { host: 'https://quotelist-4597d721fe3e.herokuapp.com' }
+  config.action_mailer.default_url_options = { host: 'https://quotetodo.com' }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
独自ドメインの取得と設定によりログアウトとプロフィール編集ができなくなった。
原因
HTTP Originヘッダーとリクエストされたbase_urlが一致していないために発生。具体的には、https://quotetodo.comとhttp://quotetodo.comが一致していないことが原因。このような場合、CSRFトークンの検証が失敗し、リクエストが拒否されるっぽい（ActionController::InvalidAuthenticityTokenエラー）。

対応
HTTPSを強制させることで不一致を解決させる。